### PR TITLE
update testcafe dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "plugin"
   ],
   "dependencies": {
-      "testcafe": "^0.14.0"
+      "testcafe": "^0.15.0"
   }
 }


### PR DESCRIPTION
^0.14 in package.json won't pull the latest (^0.15), which was breaking the vue selector for me