### PR TITLE
fix semver for testcafe

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "http-server": "^0.9.0",
     "publish-please": "^2.2.0",
     "vue": "^2.1.10",
-    "testcafe": "^0.15.0"
+    "testcafe": "*"
   },
   "keywords": [
     "testcafe",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "plugin"
   ],
   "peerDependencies": {
-      "testcafe": ">=0.15.0"
+      "testcafe": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-vue-selectors",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "VueJS selectors for TestCafe",
   "repository": "https://github.com/DevExpress/testcafe-vue-selectors",
   "author": {
@@ -40,6 +40,6 @@
     "plugin"
   ],
   "peerDependencies": {
-      "testcafe": "^0.15.0"
+      "testcafe": ">=0.15.0"
   }
 }


### PR DESCRIPTION
`^0.15.0` will match the following versions `>=0.15.0 <0.16.0`
`>=0.15.0` will match all version greater than `0.15.0`.
@AlexanderMoskovkin 