### PR TITLE
Bump version (v3.1.1)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parser": "@babel/eslint-parser",
+  "parser": "esprima",
   "extends": "eslint:recommended",
   "parserOptions": {
     "ecmaVersion": 6,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
 {
-  "parser": "esprima",
   "extends": "eslint:recommended",
   "parserOptions": {
     "ecmaVersion": 6,
@@ -36,6 +35,7 @@
     "no-spaced-func": 2,
     "no-undef-init": 2,
     "no-unused-expressions": 2,
+    "no-var": 2,
     "no-with": 2,
     "camelcase": 2,
     "comma-spacing": 2,

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,5 @@ Temporary Items
 
 node_modules/*
 .idea/*
-lib/*
 test/data/lib/*
 package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 exports.__esModule = true;
 exports['default'] = void 0;
 
-var Selector = require('testcafe').Selector;
+const Selector = require('testcafe').Selector;
 
 exports['default'] = Selector(complexSelector => {
     function validateSelector (selector) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const Selector = require('testcafe').Selector;
+const { Selector } = require('testcafe');
 
 module.exports = Selector(complexSelector => {
     function validateSelector (selector) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,11 @@
-import { Selector } from 'testcafe';
+'use strict';
 
-export default Selector(complexSelector => {
+exports.__esModule = true;
+exports['default'] = void 0;
+
+var Selector = require('testcafe').Selector;
+
+exports['default'] = Selector(complexSelector => {
     function validateSelector (selector) {
         if (selector !== void 0 && typeof selector !== 'string')
             throw new Error('If the selector parameter is passed it should be a string, but it was ' + eval('typeof selector')); // eslint-disable-line no-eval
@@ -95,9 +100,9 @@ export default Selector(complexSelector => {
         }
 
         walkVueComponentNodes(root, 0, (node, tagIndex) => {
-            if (isRef(tags[tagIndex])) {       
+            if (isRef(tags[tagIndex])) {
                 const ref = getRef(tags[tagIndex]);
-                
+
                 return ref === getRefOfNode(node);
             }
             return tags[tagIndex] === getComponentTag(node);
@@ -157,7 +162,7 @@ export default Selector(complexSelector => {
         }
 
         function getComponentReference (instance) {
-            return instance.$vnode && instance.$vnode.data && instance.$vnode.data.ref;   
+            return instance.$vnode && instance.$vnode.data && instance.$vnode.data.ref;
         }
 
         const nodeVue = node.__vue__;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,9 @@
-'use strict';
-
-exports.__esModule = true;
-exports['default'] = void 0;
-
 const Selector = require('testcafe').Selector;
 
-exports['default'] = Selector(complexSelector => {
+module.exports = Selector(complexSelector => {
     function validateSelector (selector) {
         if (selector !== void 0 && typeof selector !== 'string')
-            throw new Error('If the selector parameter is passed it should be a string, but it was ' + eval('typeof selector')); // eslint-disable-line no-eval
+            throw new Error('If the selector parameter is passed it should be a string, but it was ' + typeof selector);
     }
 
     function validateVueVersion (rootInstance) {
@@ -19,19 +14,14 @@ exports['default'] = Selector(complexSelector => {
             throw new Error('testcafe-vue-selectors supports Vue version 2.x and newer');
     }
 
-    /*eslint-disable no-unused-vars, no-eval*/
     function findVueConstructor (rootInstance) {
-        // NOTE: Testcafe does not support a ClientFunction containing polyfilled functions. See list in
-        // https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/definitions.js.
-        // This is why, we use this hack.
-        let Vue = eval('Object.getPrototypeOf(rootInstance)').constructor;
+        let Vue = Object.getPrototypeOf(rootInstance).constructor;
 
         while (Vue.super)
             Vue = Vue.super;
 
         return Vue;
     }
-    /*eslint-enable no-unused-vars, no-eval*/
 
     function findFirstRootInstance () {
         let instance     = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-vue-selectors",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "VueJS selectors for TestCafe",
   "repository": "https://github.com/DevExpress/testcafe-vue-selectors",
   "author": {

--- a/package.json
+++ b/package.json
@@ -13,18 +13,14 @@
   ],
   "license": "MIT",
   "scripts": {
-    "lint": "eslint src/index.js",
+    "lint": "eslint lib/index.js",
     "test-server": "webpack-dev-server",
     "testcafe": "testcafe all test/*.js --app \"npm run test-server\" --app-init-delay 10000",
-    "test": "npm run lint && npm run build && npm run testcafe",
-    "build": "babel src --out-dir lib",
+    "test": "npm run lint && npm run testcafe",
     "publish-please": "publish-please",
     "prepublish": "publish-please guard"
   },
   "devDependencies": {
-    "@babel/cli": "^7.13.0",
-    "@babel/core": "^7.13.8",
-    "@babel/eslint-parser": "^7.13.8",
     "babel-loader": "^8.2.2",
     "css-loader": "^5.1.1",
     "eslint": "^7.21.0",


### PR DESCRIPTION
### Changes
1. Remove `Babel`, `eval` hacks and the `build` task
2. Move code base to `\lib`
3. Use default ESLint parser
