### PR TITLE
Add findVue method to search for nested components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,121 +1,137 @@
 const { Selector } = require('testcafe');
 
 module.exports = Selector(complexSelector => {
-    function validateSelector (selector) {
-        if (selector !== void 0 && typeof selector !== 'string')
-            throw new Error('If the selector parameter is passed it should be a string, but it was ' + typeof selector);
-    }
-
-    function validateVueVersion (rootInstance) {
-        const MAJOR_SUPPORTED_VUE_VERSION = 2;
-        const vueVersion                  = parseInt(findVueConstructor(rootInstance).version.split('.')[0], 10);
-
-        if (vueVersion < MAJOR_SUPPORTED_VUE_VERSION)
-            throw new Error('testcafe-vue-selectors supports Vue version 2.x and newer');
-    }
-
-    function findVueConstructor (rootInstance) {
-        let Vue = Object.getPrototypeOf(rootInstance).constructor;
-
-        while (Vue.super)
-            Vue = Vue.super;
-
-        return Vue;
-    }
-
-    function findFirstRootInstance () {
-        let instance     = null;
+    window['%findVueRoot%'] = (node = document) => {
         const treeWalker = document.createTreeWalker(
-            document,
+            node,
             NodeFilter.SHOW_ELEMENT,
             () => NodeFilter.FILTER_ACCEPT,
             false
         );
 
+        let instance = node.__vue__;
+
         while (!instance && treeWalker.nextNode())
             instance = treeWalker.currentNode.__vue__;
 
         return instance;
-    }
+    };
 
-    function getComponentTagNames (componentSelector) {
-        return componentSelector
-            .split(' ')
-            .filter(el => !!el)
-            .map(el => el.trim());
-    }
-
-    function getComponentTag (instance) {
-        return instance.$options.name ||
-               instance.$options._componentTag ||
-               instance.$options.__file ||
-               '';
-    }
-
-    function isRef (selector) {
-        return selector.indexOf('ref:') !== -1;
-    }
-
-    function getRef (selector) {
-        if (selector.indexOf('ref:') === 0 && selector.split('ref:')[1])
-            return selector.split('ref:')[1];
-
-        throw new Error('If the ref is passed as selector it should be in the format \'ref:ref-selector\'');
-    }
-
-    function getRefOfNode (node) {
-        if (node.$vnode && node.$vnode.data)
-            return node.$vnode.data.ref;
-        return null;
-    }
-
-    function filterNodes (root, tags) {
-        const foundComponents = [];
-
-        function walkVueComponentNodes (node, tagIndex, checkFn) {
-            if (checkFn(node, tagIndex)) {
-                if (tagIndex === tags.length - 1) {
-                    foundComponents.push(node.$el);
-                    return;
-                }
-
-                tagIndex++;
-            }
-
-            for (let i = 0; i < node.$children.length; i++) {
-                const childNode = node.$children[i];
-
-                walkVueComponentNodes(childNode, tagIndex, checkFn);
-            }
+    window['%vueSelector%'] = (complexSelector_, vueRoots = null) => {
+        function validateSelector (selector) {
+            if (selector !== void 0 && typeof selector !== 'string')
+                throw new Error('If the selector parameter is passed it should be a string, but it was ' + typeof selector);
         }
 
-        walkVueComponentNodes(root, 0, (node, tagIndex) => {
-            if (isRef(tags[tagIndex])) {
-                const ref = getRef(tags[tagIndex]);
+        function validateVueVersion (rootInstance) {
+            const MAJOR_SUPPORTED_VUE_VERSION = 2;
+            const vueVersion                  = parseInt(findVueConstructor(rootInstance).version.split('.')[0], 10);
 
-                return ref === getRefOfNode(node);
+            if (vueVersion < MAJOR_SUPPORTED_VUE_VERSION)
+                throw new Error('testcafe-vue-selectors supports Vue version 2.x and newer');
+        }
+
+        function findVueConstructor (rootInstance) {
+            let Vue = Object.getPrototypeOf(rootInstance).constructor;
+
+            while (Vue.super)
+                Vue = Vue.super;
+
+            return Vue;
+        }
+
+        function getComponentTagNames (componentSelector) {
+            return componentSelector
+                .split(' ')
+                .filter(el => !!el)
+                .map(el => el.trim());
+        }
+
+        function getComponentTag (instance) {
+            return instance.$options.name ||
+                   instance.$options._componentTag ||
+                   instance.$options.__file ||
+                   '';
+        }
+
+        function isRef (selector) {
+            return selector.indexOf('ref:') !== -1;
+        }
+
+        function getRef (selector) {
+            if (selector.indexOf('ref:') === 0 && selector.split('ref:')[1])
+                return selector.split('ref:')[1];
+
+            throw new Error('If the ref is passed as selector it should be in the format \'ref:ref-selector\'');
+        }
+
+        function getRefOfNode (node) {
+            if (node.$vnode && node.$vnode.data)
+                return node.$vnode.data.ref;
+            return null;
+        }
+
+        function filterNodes (roots, tags) {
+            const foundComponents = [];
+
+            function walkVueComponentNodes (node, tagIndex, checkFn) {
+                if (checkFn(node, tagIndex)) {
+                    if (tagIndex === tags.length - 1) {
+                        if (foundComponents.indexOf(node.$el) === -1)
+                            foundComponents.push(node.$el);
+                        return;
+                    }
+
+                    tagIndex++;
+                }
+
+                for (let i = 0; i < node.$children.length; i++) {
+                    const childNode = node.$children[i];
+
+                    walkVueComponentNodes(childNode, tagIndex, checkFn);
+                }
             }
-            return tags[tagIndex] === getComponentTag(node);
-        });
-        return foundComponents;
-    }
+
+            roots.forEach(root => {
+                walkVueComponentNodes(root, 0, (node, tagIndex) => {
+                    if (isRef(tags[tagIndex])) {
+                        const ref = getRef(tags[tagIndex]);
+
+                        return ref === getRefOfNode(node);
+                    }
+                    return tags[tagIndex] === getComponentTag(node);
+                });
+            });
+
+            return foundComponents;
+        }
 
 
-    validateSelector(complexSelector);
+        validateSelector(complexSelector_);
+        
+        const rootInstances = vueRoots ? vueRoots : [];
 
-    const rootInstance = findFirstRootInstance();
+        if (!vueRoots) {
+            const documentRoot = window['%findVueRoot%']();
 
-    if (!rootInstance)
-        return null;
+            if (documentRoot) 
+                rootInstances.push(documentRoot);
 
-    validateVueVersion(rootInstance);
+            if (!documentRoot)
+                return null;
+        }
 
-    if (!complexSelector)
-        return rootInstance.$el;
+        rootInstances.map(validateVueVersion);
 
-    const componentTags = getComponentTagNames(complexSelector);
+        if (!complexSelector_)
+            return rootInstances.map(node => node.$el);
 
-    return filterNodes(rootInstance, componentTags);
+        const componentTags = getComponentTagNames(complexSelector_);
+
+        return filterNodes(rootInstances, componentTags);
+    };
+
+    return window['%vueSelector%'](complexSelector);
 }).addCustomMethods({
     getVue: (node, fn) => {
         function getData (instance, prop) {
@@ -170,4 +186,8 @@ module.exports = Selector(complexSelector => {
 
         return { props, state, computed, ref };
     }
-});
+}).addCustomMethods({
+    findVue: (nodes, selector) => {
+        return window['%vueSelector%'](selector, nodes.map(window['%findVueRoot%']));
+    },
+}, { returnDOMNodes: true });

--- a/test/data/vue-js/index.html
+++ b/test/data/vue-js/index.html
@@ -9,6 +9,7 @@
 <div id="app">
     <list id="list1" ref="list-1"></list>
     <list id="list2" ref="list-2"></list>
+    <list-item id="extra" ref="extra-list-item"></list-item>
 </div>
 <script>
     Vue.component('list-item', {

--- a/test/vue-js.js
+++ b/test/vue-js.js
@@ -19,13 +19,30 @@ test('selector', async t => {
 
     await t
         .expect(list.count).eql(2)
-        .expect(VueSelector('list-item').count).eql(6)
+        .expect(VueSelector('list-item').count).eql(7)
         .expect(listVue.props.id).eql('list1')
         .expect(listVue.computed.reversedId).eql('1tsil');
 });
 
 test('composite selector', async t => {
     const listItem       = VueSelector('list list-item');
+    const listItemVue6   = await listItem.nth(5).getVue();
+    const listItemVue5Id = listItem.nth(4).getVue(({ props }) => props.id);
+
+    await t
+        .expect(listItem.count).eql(6)
+        .expect(listItemVue6.props.id).eql('list2-item3')
+        .expect(listItemVue5Id).eql('list2-item2');
+});
+
+test('findVue chain selector', async t => {
+    const allListItem       = VueSelector().findVue('list-item');
+
+    await t
+        .expect(allListItem.count).eql(7)
+        .expect((await allListItem.nth(6).getVue()).props.id).eql('extra');
+
+    const listItem       = VueSelector('list').findVue('list-item');
     const listItemVue6   = await listItem.nth(5).getVue();
     const listItemVue5Id = listItem.nth(4).getVue(({ props }) => props.id);
 


### PR DESCRIPTION
Added findVue method to search for nested components.

Addresses #58 

**Usage example:**

```js
VueSelector('list').findVue('list-item');
```

**Changes:**
Since I indented a lot of the code one level the diff is hard to read, so here is a summary of code changes.
- The inner function in the selector has been abstracted into a function `window['%vueSelector%']` that takes vue roots as an optional second parameter. This function is used without the second argument for the base selector and uses the argument for `findVue`.
- The function `findFirstRootInstance` has been replaced with a generic `window['%findVueRoot%']` that is used to find the first vue elements from descending from any node (`document` in the case of `findFirstRootInstance`). This function is also used in `findVue`.

**Implementation details:**

Since TestCafe evaluates the function source separately from the original context, using external variables does not work within a TestCafe Selector. So, a solution like this would not work.
```js
function VueSelector(selector, options) {
    ...
}
Selector(selector => {
    return VueSelector(selector);
}).addCustomMethods({
    findVue: (nodes, selector) => {
        return VueSelector(selector, { nodes });
    },
}, { returnDOMNodes: true });
```
It would result in an error like `VueSelector is not defined`.

Instead, I had to do something like this using `window` properties (similar to [testcafe-react-selectors](https://github.com/DevExpress/testcafe-react-selectors)).

```js
Selector(selector => {
    window['%vueSelector%'] = (selector, options) => { ... };
    return VueSelector(selector);
}).addCustomMethods({
    findVue: (nodes, selector) => {
        return window['%vueSelector%'](selector, { nodes });
    },
}, { returnDOMNodes: true });